### PR TITLE
Fix signature verification and tx replay acceptance hardening

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -98,6 +98,9 @@ var (
 	// to contain a 65 byte secp256k1 signature.
 	errMissingSignature = errors.New("extra-data 65 byte signature suffix missing")
 
+	// errInvalidSignature is returned if the signature is malformed or non-canonical.
+	errInvalidSignature = errors.New("invalid signature")
+
 	// errExtraSigners is returned if non-checkpoint block contain signer data in
 	// their extra-data fields.
 	errExtraSigners = errors.New("non-checkpoint block contains extra signer list")
@@ -154,6 +157,14 @@ func ecrecover(header *types.Header, sigcache *sigLRU) (common.Address, error) {
 		return common.Address{}, errMissingSignature
 	}
 	signature := header.Extra[len(header.Extra)-extraSeal:]
+	r := new(big.Int).SetBytes(signature[:32])
+	s := new(big.Int).SetBytes(signature[32:64])
+	v := signature[64]
+
+	// Clique uses Homestead low-s rules to reject malleable seals.
+	if !crypto.ValidateSignatureValues(v, r, s, true) {
+		return common.Address{}, errInvalidSignature
+	}
 
 	// Recover the public key and the Ethereum address
 	pubkey, err := crypto.Ecrecover(SealHash(header).Bytes(), signature)
@@ -303,6 +314,9 @@ func (c *Clique) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 	}
 	if chain.Config().IsCancun(header.Time) {
 		return fmt.Errorf("clique does not support cancun fork")
+	}
+	if header.WithdrawalsHash != nil {
+		return fmt.Errorf("unexpected withdrawals root in clique header")
 	}
 	// All basic checks passed, verify cascading fields
 	return c.verifyCascadingFields(chain, header, parents)

--- a/consensus/clique/signature_test.go
+++ b/consensus/clique/signature_test.go
@@ -1,0 +1,187 @@
+package clique
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestCliqueRejectsMalleatedSeal(t *testing.T) {
+	var (
+		db      = rawdb.NewMemoryDatabase()
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		signer  = crypto.PubkeyToAddress(key.PublicKey)
+		config  = *params.AllCliqueProtocolChanges
+		cliqueC = *params.AllCliqueProtocolChanges.Clique
+	)
+
+	cliqueC.Period = 1
+	config.Clique = &cliqueC
+	config.CepheusBlock = big.NewInt(0)
+	genesis := &core.Genesis{
+		Config:    &config,
+		ExtraData: make([]byte, extraVanity+common.AddressLength+extraSeal),
+		GasLimit:  10_000_000,
+		BaseFee:   big.NewInt(params.InitialBaseFee),
+		Alloc: map[common.Address]core.GenesisAccount{
+			signer: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+		},
+	}
+
+	copy(genesis.ExtraData[extraVanity:], signer[:])
+	engine := New(config.Clique, db)
+	chain, err := core.NewBlockChain(db, nil, genesis, nil, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create clique chain: %v", err)
+	}
+
+	defer chain.Stop()
+	parent := chain.CurrentHeader()
+	original := &types.Header{
+		ParentHash:  parent.Hash(),
+		UncleHash:   types.EmptyUncleHash,
+		Coinbase:    common.Address{},
+		Root:        parent.Root,
+		TxHash:      types.EmptyTxsHash,
+		ReceiptHash: types.EmptyReceiptsHash,
+		Bloom:       types.Bloom{},
+		Difficulty:  new(big.Int).Set(diffInTurn),
+		Number:      new(big.Int).Add(parent.Number, common.Big1),
+		GasLimit:    parent.GasLimit,
+		GasUsed:     0,
+		Time:        parent.Time + config.Clique.Period,
+		Extra:       make([]byte, extraVanity+extraSeal),
+		MixDigest:   common.Hash{},
+		Nonce:       types.BlockNonce{},
+		BaseFee:     misc.CalcBaseFee(&config, parent),
+	}
+
+	sig, err := crypto.Sign(SealHash(original).Bytes(), key)
+	if err != nil {
+		t.Fatalf("failed to sign clique header: %v", err)
+	}
+
+	copy(original.Extra[len(original.Extra)-extraSeal:], sig)
+	forged := types.CopyHeader(original)
+	malleated := malleateSignature(sig)
+	copy(forged.Extra[len(forged.Extra)-extraSeal:], malleated)
+
+	if original.Hash() == forged.Hash() {
+		t.Fatal("expected different block hashes for original and forged seal")
+	}
+
+	if SealHash(original) != SealHash(forged) {
+		t.Fatalf("expected identical seal hash, have %s want %s", SealHash(forged), SealHash(original))
+	}
+
+	if err := engine.VerifyHeader(chain, original, true); err != nil {
+		t.Fatalf("original header rejected: %v", err)
+	}
+
+	if err := engine.VerifyHeader(chain, forged, true); err == nil {
+		t.Fatal("expected malleated header to be rejected")
+	}
+
+	if SealHash(original) != SealHash(forged) {
+		t.Fatalf("expected identical seal hash, have %s want %s", SealHash(forged), SealHash(original))
+	}
+
+	authorOriginal, err := engine.Author(original)
+	if err != nil {
+		t.Fatalf("failed to recover original signer: %v", err)
+	}
+
+	if authorOriginal != signer {
+		t.Fatalf("expected original header to recover signer %s, got %s", signer, authorOriginal)
+	}
+}
+
+func TestCliqueRejectsPreShanghaiHeaderWithWithdrawalsRoot(t *testing.T) {
+	t.Parallel()
+	var (
+		db      = rawdb.NewMemoryDatabase()
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		signer  = crypto.PubkeyToAddress(key.PublicKey)
+		config  = *params.AllCliqueProtocolChanges
+		cliqueC = *params.AllCliqueProtocolChanges.Clique
+	)
+
+	cliqueC.Period = 1
+	config.Clique = &cliqueC
+	config.CepheusBlock = big.NewInt(0)
+	genesis := &core.Genesis{
+		Config:    &config,
+		ExtraData: make([]byte, extraVanity+common.AddressLength+extraSeal),
+		GasLimit:  10_000_000,
+		BaseFee:   big.NewInt(params.InitialBaseFee),
+		Alloc: map[common.Address]core.GenesisAccount{
+			signer: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+		},
+	}
+
+	copy(genesis.ExtraData[extraVanity:], signer[:])
+	engine := New(config.Clique, db)
+	chain, err := core.NewBlockChain(db, nil, genesis, nil, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create clique chain: %v", err)
+	}
+
+	defer chain.Stop()
+	parent := chain.CurrentHeader()
+	if config.IsShanghai(parent.Time) {
+		t.Fatal("test expects pre-Shanghai chain config (AllCliqueProtocolChanges)")
+	}
+
+	wh := types.EmptyWithdrawalsHash
+	crafted := &types.Header{
+		ParentHash:      parent.Hash(),
+		UncleHash:       types.EmptyUncleHash,
+		Coinbase:        common.Address{},
+		Root:            parent.Root,
+		TxHash:          types.EmptyTxsHash,
+		ReceiptHash:     types.EmptyReceiptsHash,
+		Bloom:           types.Bloom{},
+		Difficulty:      new(big.Int).Set(diffInTurn),
+		Number:          new(big.Int).Add(parent.Number, common.Big1),
+		GasLimit:        parent.GasLimit,
+		GasUsed:         0,
+		Time:            parent.Time + config.Clique.Period,
+		Extra:           make([]byte, extraVanity+extraSeal),
+		MixDigest:       common.Hash{},
+		Nonce:           types.BlockNonce{},
+		BaseFee:         misc.CalcBaseFee(&config, parent),
+		WithdrawalsHash: &wh,
+	}
+
+	// Any 65-byte ECDSA signature with valid (v,r,s) reaches ecrecover → SealHash
+	// on vulnerable code; we only need to prove VerifyHeader does not panic.
+	sig, err := crypto.Sign(make([]byte, 32), key)
+	if err != nil {
+		t.Fatalf("failed to create signature bytes: %v", err)
+	}
+	copy(crafted.Extra[len(crafted.Extra)-extraSeal:], sig)
+
+	err = engine.VerifyHeader(chain, crafted, true)
+	if err == nil || err.Error() != "unexpected withdrawals root in clique header" {
+		t.Fatalf("expected withdrawals-root rejection error, got %v", err)
+	}
+}
+
+func malleateSignature(sig []byte) []byte {
+	out := append([]byte(nil), sig...)
+	s := new(big.Int).SetBytes(out[32:64])
+	s.Sub(crypto.S256().Params().N, s)
+	sBytes := s.FillBytes(make([]byte, 32))
+	copy(out[32:64], sBytes)
+	out[64] ^= 1
+
+	return out
+}

--- a/core/replay_execute_test.go
+++ b/core/replay_execute_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestWbtMainnetTransactionToMessageRejectsUnprotectedLegacyTx(t *testing.T) {
+	t.Parallel()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := types.SignTx(
+		types.NewTransaction(0, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1), params.TxGas, big.NewInt(1), nil),
+		types.HomesteadSigner{},
+		key,
+	)
+	if err != nil {
+		t.Fatalf("sign tx: %v", err)
+	}
+	if tx.Protected() {
+		t.Fatal("expected unprotected legacy tx")
+	}
+	signer := types.MakeSigner(params.WbtMainnetChainConfig, big.NewInt(1))
+	_, err = TransactionToMessage(tx, signer, nil)
+	if !errors.Is(err, types.ErrTxTypeNotSupported) {
+		t.Fatalf("expected ErrTxTypeNotSupported, got %v", err)
+	}
+}

--- a/core/txpool/replay_accept_test.go
+++ b/core/txpool/replay_accept_test.go
@@ -1,0 +1,49 @@
+package txpool
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// TestWbtMainnetTxPoolRejectsUnprotectedLegacyTransactions ensures unprotected
+// legacy txs are rejected on remote ingestion for the WhiteBIT mainnet chain.
+func TestWbtMainnetTxPoolRejectsUnprotectedLegacyTransactions(t *testing.T) {
+	t.Parallel()
+	pool, key := setupPoolWithConfig(params.WbtMainnetChainConfig)
+	defer pool.Stop()
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, from, new(big.Int).Mul(big.NewInt(params.Ether), big.NewInt(10)))
+	tx, err := types.SignTx(
+		types.NewTransaction(0, from, big.NewInt(1), params.TxGas, big.NewInt(1), nil),
+		types.HomesteadSigner{},
+		key,
+	)
+
+	if err != nil {
+		t.Fatalf("failed to sign unprotected tx: %v", err)
+	}
+
+	if tx.Protected() {
+		t.Fatal("expected test transaction to be unprotected")
+	}
+
+	errs := pool.AddRemotesSync([]*types.Transaction{tx})
+	if len(errs) != 1 {
+		t.Fatalf("unexpected error slice length: %d", len(errs))
+	}
+
+	if !errors.Is(errs[0], core.ErrTxTypeNotSupported) {
+		t.Fatalf("expected ErrTxTypeNotSupported, got %v", errs[0])
+	}
+
+	pending, _ := pool.ContentFrom(from)
+	if len(pending) != 0 {
+		t.Fatalf("expected empty pending pool, got %d txs", len(pending))
+	}
+}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -636,6 +636,9 @@ func (pool *TxPool) validateTxBasics(tx *types.Transaction, local bool) error {
 	}
 	// Make sure the transaction is signed properly.
 	if _, err := types.Sender(pool.signer, tx); err != nil {
+		if errors.Is(err, types.ErrTxTypeNotSupported) {
+			return err
+		}
 		return ErrInvalidSender
 	}
 	// Drop non-local transactions under our own minimal accepted gas price or tip

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -258,7 +258,7 @@ func (s eip2930Signer) Sender(tx *Transaction) (common.Address, error) {
 	switch tx.Type() {
 	case LegacyTxType:
 		if !tx.Protected() {
-			return HomesteadSigner{}.Sender(tx)
+			return common.Address{}, ErrTxTypeNotSupported
 		}
 		V = new(big.Int).Sub(V, s.chainIdMul)
 		V.Sub(V, big8)
@@ -361,7 +361,7 @@ func (s EIP155Signer) Sender(tx *Transaction) (common.Address, error) {
 		return common.Address{}, ErrTxTypeNotSupported
 	}
 	if !tx.Protected() {
-		return HomesteadSigner{}.Sender(tx)
+		return common.Address{}, ErrTxTypeNotSupported
 	}
 	if tx.ChainId().Cmp(s.chainId) != 0 {
 		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)

--- a/p2p/discover/pubkey_test.go
+++ b/p2p/discover/pubkey_test.go
@@ -1,0 +1,70 @@
+package discover
+
+import (
+	"math/big"
+	"net"
+	"testing"
+
+	ethmath "github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/discover/v4wire"
+)
+
+func findSmallCurvePoint(t *testing.T) (*big.Int, *big.Int) {
+	t.Helper()
+
+	params := crypto.S256().Params()
+	two256 := new(big.Int).Lsh(big.NewInt(1), 256)
+	limit := new(big.Int).Sub(two256, params.P) // need x < 2^256 - P so x+P still fits in 32 bytes
+
+	for i := int64(1); ; i++ {
+		x := big.NewInt(i)
+		if x.Cmp(limit) >= 0 {
+			t.Fatal("failed to find small curve point")
+		}
+		rhs := new(big.Int).Mul(x, x)
+		rhs.Mul(rhs, x)
+		rhs.Add(rhs, params.B)
+		rhs.Mod(rhs, params.P)
+
+		y := new(big.Int).ModSqrt(rhs, params.P)
+		if y != nil {
+			return x, y
+		}
+	}
+}
+
+func encodeBadPubkey(x, y *big.Int) (out v4wire.Pubkey) {
+	ethmath.ReadBits(x, out[:32])
+	ethmath.ReadBits(y, out[32:])
+	return out
+}
+
+func TestMalformedNeighborPubkeyRejected(t *testing.T) {
+	x, y := findSmallCurvePoint(t)
+	badX := new(big.Int).Add(x, crypto.S256().Params().P)
+
+	rn := v4wire.Node{
+		IP:  net.ParseIP("127.0.0.1").To4(),
+		UDP: 30303,
+		TCP: 30303,
+		ID:  encodeBadPubkey(badX, y),
+	}
+
+	if _, err := v4wire.DecodePubkey(crypto.S256(), rn.ID); err == nil {
+		t.Fatal("expected non-canonical pubkey to be rejected")
+	}
+
+	var udp UDPv4
+	sender := &net.UDPAddr{IP: net.ParseIP("127.0.0.1").To4(), Port: 30303}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+
+	if _, err := udp.nodeFromRPC(sender, rn); err == nil {
+		t.Fatal("expected nodeFromRPC to fail on bad pubkey")
+	}
+}

--- a/p2p/discover/v4wire/v4wire.go
+++ b/p2p/discover/v4wire/v4wire.go
@@ -287,6 +287,14 @@ func DecodePubkey(curve elliptic.Curve, e Pubkey) (*ecdsa.PublicKey, error) {
 	half := len(e) / 2
 	p.X.SetBytes(e[:half])
 	p.Y.SetBytes(e[half:])
+
+	// Must use canonical encoding (0 <= X,Y < P)
+	if params := curve.Params(); params != nil && params.P != nil {
+		if p.X.Cmp(params.P) >= 0 || p.Y.Cmp(params.P) >= 0 {
+			return nil, ErrBadPoint
+		}
+	}
+
 	if !p.Curve.IsOnCurve(p.X, p.Y) {
 		return nil, ErrBadPoint
 	}


### PR DESCRIPTION
## Summary

- harden signature/public key validation paths in Clique and discovery code to prevent malformed input from being accepted
- tighten transaction replay acceptance/signing checks in txpool and transaction signing flows
- add targeted regression tests for signature recovery, pubkey validation, txpool replay acceptance, and replay execution behavior

## Why
These changes close security-sensitive edge cases where invalid signatures or replay-like inputs could be processed incorrectly.

## Tests
```
go test ./consensus/clique -run 'TestCliqueRejectsMalleatedSeal|TestCliqueRejectsPreShanghaiHeaderWithWithdrawalsRoot'
go test ./core -run 'TestWbtMainnetTransactionToMessageRejectsUnprotectedLegacyTx'
go test ./core/txpool -run 'TestWbtMainnetTxPoolRejectsUnprotectedLegacyTransactions'
go test ./p2p/discover -run 'TestMalformedNeighborPubkeyRejected'
```